### PR TITLE
Fixing newick parsing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The `gotree` executable should be located in the current folder (or the `$GOPATH
 
 To test the executable:
 ```
-./test.sh
+bash test.sh
 ```
 
 ## Auto completion

--- a/io/fileutils/readln.go
+++ b/io/fileutils/readln.go
@@ -37,7 +37,13 @@ func ReadUntilSemiColon(r *bufio.Reader) (string, error) {
 		line, isPrefix, err = r.ReadLine()
 		ln = append(ln, line...)
 		if len(ln) > 0 {
-			lastChar = ln[len(ln)-1]
+			i := len(ln) - 1
+			lastChar = ln[i]
+			// Test what last non-space character of the line is
+			for (lastChar == ' ' || lastChar == '\t') && i >= 0 {
+				i--
+				lastChar = ln[i]
+			}
 		}
 	}
 	return string(ln), err


### PR DESCRIPTION
This PR fixes #22. 

I changed `ReadUntilSemiColon` so that the `lastChar` variable checks the last non space or `\t` character in a line.  

All the tests should keep passing *(they do on my machine)*. 

**N.B:** I also changed the instructions on how to run the test script in the README.md file. My default shell is zsh, as such if I just execute  `./test.sh` the script fails, running `bash test.sh` yields the expected results. 