### PR TITLE
Use a shebang to enforce running test.sh in bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The `gotree` executable should be located in the current folder (or the `$GOPATH
 
 To test the executable:
 ```
-bash test.sh
+./test.sh
 ```
 
 ## Auto completion

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ########## Test Suite for Gotree command line tools ##############
 
 set -e


### PR DESCRIPTION
Commit b959a7f3eccdebda804206232a37f1d651f5dd5c was made because `test.sh` cannot run on systems where the default shell is not bash compatible (e.g. zsh). (cf https://github.com/evolbioinfo/gotree/pull/23)

A [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) allows to force the use of bash to interpret the shell script. This version using `/usr/bin/env` should be the most portable.

@lucblassel It this working fine for you?