### PR TITLE
fix: correct Unkown->Unknown typo in error messages

### DIFF
--- a/acr/parsimony.go
+++ b/acr/parsimony.go
@@ -69,7 +69,7 @@ func ParsimonyAcr(t *tree.Tree, tipCharacters map[string]string, algo int, rando
 	case ALGO_NONE:
 		// No pass after uppass
 	default:
-		err = fmt.Errorf("Parsimony algorithm %d unkown", algo)
+		err = fmt.Errorf("Parsimony algorithm %d unknown", algo)
 		return
 	}
 

--- a/asr/parsimony.go
+++ b/asr/parsimony.go
@@ -63,7 +63,7 @@ func ParsimonyAsr(t *tree.Tree, a align.Alignment, algo int, randomResolve bool,
 	case ALGO_ACCTRAN:
 		parsimonyACCTRAN(t.Root(), nil, a, seqs, charToIndex, randomResolve, rand)
 	default:
-		err = fmt.Errorf("parsimony algorithm %d unkown", algo)
+		err = fmt.Errorf("parsimony algorithm %d unknown", algo)
 		return
 	}
 

--- a/cmd/acr.go
+++ b/cmd/acr.go
@@ -61,7 +61,7 @@ randomly before going deeper in the tree.
 		case "none":
 			algo = acr.ALGO_NONE
 		default:
-			io.LogError(fmt.Errorf("Unkown parsimony algorithm: %s", parsimonyAlgo))
+			io.LogError(fmt.Errorf("Unknown parsimony algorithm: %s", parsimonyAlgo))
 			return
 		}
 		// Reading tip state in an input file

--- a/cmd/asr.go
+++ b/cmd/asr.go
@@ -64,7 +64,7 @@ randomly before going deeper in the tree.
 		case "none":
 			algo = asr.ALGO_NONE
 		default:
-			err = fmt.Errorf("unkown parsimony algorithm: %s", parsimonyAlgo)
+			err = fmt.Errorf("unknown parsimony algorithm: %s", parsimonyAlgo)
 			io.LogError(err)
 			return
 		}

--- a/cmd/itoldl.go
+++ b/cmd/itoldl.go
@@ -52,7 +52,7 @@ phyloxml
 				return
 			}
 		case download.FORMAT_UNKNOWN:
-			err = errors.New("Unkown format: " + dlformat)
+			err = errors.New("Unknown format: " + dlformat)
 			io.LogError(err)
 			return
 		}


### PR DESCRIPTION
Fixes 5 instances of `Unkown` typo → `Unknown` in error messages:

- `cmd/itoldl.go:55`: `Unkown format` → `Unknown format`
- `cmd/acr.go:64`: `Unkown parsimony algorithm` → `Unknown parsimony algorithm`
- `cmd/asr.go:67`: `unkown parsimony algorithm` → `unknown parsimony algorithm`
- `acr/parsimony.go:72`: `Parsimony algorithm %d unkown` → `Parsimony algorithm %d unknown`
- `asr/parsimony.go:66`: `parsimony algorithm %d unkown` → `parsimony algorithm %d unknown`

All typos are in error messages shown to users when invalid input is provided.